### PR TITLE
Image url already has the protocol, so no need to add it.

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -54,7 +54,7 @@ export function getSrc($: cheerio.Root): string | null {
 
   if (image == null) return null
 
-  const src = 'https:' + image.attribs.href
+  const src = image.attribs.href
   return src
 }
 


### PR DESCRIPTION
As you're using the image url from the tag, there's no need to add the protocol a second time.